### PR TITLE
Replaced Cognito form with the static contact button

### DIFF
--- a/_includes/linaro-contact-form.html
+++ b/_includes/linaro-contact-form.html
@@ -1,12 +1,8 @@
 {% unless page.url contains '/contact/' %}
     <hr />
 {% endunless %}
-<div class="cognito">
-    <script src="https://services.cognitoforms.com/s/KvRQmIn2dku6k6gGP711jw"></script>
-    <script>
-        Cognito.load("forms", { id: "13", entry: {
-          "PageUrl": "{{site.url}}{{page.url}}" ,
-          "RedirectUrl" : "{{site.url}}/thank-you/?ref={{page.url}}"
-        }});
-    </script>
+<div class="col-xs-12 text-center">
+    <a class="btn email" href="mailto:contact@linaro.org?subject=Connect.linaro.org - {{page.url}}">
+        Contact Us
+    </a>
 </div>

--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -685,3 +685,22 @@ div.sponsors {
     padding-top: 10px;
     padding-bottom: 10px;
 }
+// CSS for the email button.
+#wrapper .email {
+    height: 50px;
+    background-color: #a4d23a;
+    width: 200px;
+    line-height: 30px;
+    text-align: center;
+    color: white;
+    font-weight: bold;
+    border: 1px solid #9e9e9e;
+    margin-left: auto;
+    margin-right: auto;
+    transition: all 200ms ease;
+}
+#wrapper .email:hover {
+    background-color: #3a3a3a;
+    border: 1px solid #000000;
+    color:white;
+}


### PR DESCRIPTION
We are replacing the Cognito forms on our static websites with a simple contact button using a mailto: link and a prefilled subject line to automatically assign tickets which come in. This will allow us to track who is working on which ticket in the Service Desk portal.



