### PR TITLE
Schedule updated to include the overview schedule (#122)

### DIFF
--- a/_data/overview-schedule.yml
+++ b/_data/overview-schedule.yml
@@ -1,0 +1,71 @@
+- day_number: 1
+  date: Monday, April 1
+  slots:
+    - title: Registration Opens
+      time: 07:30 - 8:30
+    - title: Sessions
+      time: 08:30 - 09:55
+    - title: Keynotes
+      time: 10:00 - 11:00
+    - title: Team Planning sessions
+      time: 11:00 - 13:00
+    - title: Lunch
+      time: 12:00 - 14:00
+    - title: Sessions
+      time: 14:00 - 17:30
+- day_number: 2
+  date: Tuesday, April 2
+  slots:
+    - title: Sessions
+      time: 08:30 - 09:55
+    - title: Keynotes
+      time: 10:00 - 11:00
+    - title: Sessions
+      time: 11:00 - 13:00
+    - title: Lunch
+      time: 12:00 - 14:00
+    - title: Training & Hacking Sessions
+      time: 14:00 - 17:30
+    - title: Committee Member Dinner
+      time: 19:00 - 22:00
+- day_number: 3
+  date: Wednesday, April 3
+  slots:
+    - title: Sessions
+      time: 08:30 - 09:55
+    - title: Keynotes
+      time: 10:00 - 11:00
+    - title: Sessions
+      time: 11:00 - 13:00
+    - title: Lunch
+      time: 12:00 - 14:00
+    - title: Training & Hacking Sessions
+      time: 14:00 - 17:30
+    - title: Social Event for all attendees
+      time: 19:00 - 22:00
+- day_number: 4
+  date: Thursday, April 4
+  slots:
+    - title: Sessions
+      time: 08:30 - 09:55
+    - title: Keynotes
+      time: 10:00 - 11:00
+    - title: Sessions
+      time: 11:00 - 13:00
+    - title: Lunch
+      time: 12:00 - 14:00
+    - title: Training & Hacking Sessions
+      time: 14:00 - 17:30
+    - title: Member Services Dinner 
+      time: 18:30 - 01:00
+- day_number: 5
+  date: Friday, April 5
+  slots:
+    - title: Sessions
+      time: 08:30 - 09:55
+    - title: Keynotes
+      time: 10:00 - 11:00
+    - title: Sessions
+      time: 11:00 - 12:00
+    - title: Lunch & Demo Friday / End of Connect
+      time: 12:00 - 14:00

--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -689,3 +689,13 @@ div#current-sponsors {
     position: relative;
     z-index: 5;
 }
+div#schedule .list-group-item {
+    overflow: auto;
+}
+@media (min-width: $screen-sm-min) {
+  .collapse.dont-collapse-sm {
+    display: block;
+    height: auto !important;
+    visibility: visible;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -40,31 +40,12 @@ home: true
         </div>
     </div>
 </div>
-<!-- Schedule Modal -->
-<div class="modal fade" id="scheduleModal">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title">Linaro Connect Bangkok 2019 Schedule</h4>
-            </div>
-            <div class="modal-body">
-                <iframe width="100%" height="500px" data-src="https://calendar.google.com/calendar/embed?src=so80ggb57tspjgucpqn1gort0s%40group.calendar.google.com&mode=AGENDA&ctz=Asia/Bangkok&dates=20190401%2F20190405" 
-                 class="lazyload"></iframe>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 <!-- https://calendar.google.com/calendar/embed?src=so80ggb57tspjgucpqn1gort0s%40group.calendar.google.com&mode=AGENDA&ctz=Asia/Bangkok&dates=20190401%2F20190405 -->
 <div class="row flex-row upcoming-connect padded-row-30">
     <div class="container">
         <h3 class="home-text text-white">Join us in Bangkok, Thailand from April 1-5, 2019</h3>
         <a href="/register/" class="btn btn-linaro-home">Register</a>
-        <a data-toggle="modal" href="#scheduleModal" class="btn btn-linaro-home">Schedule</a>
+        <a data-toggle="modal" href="/schedule/" class="btn btn-linaro-home">Schedule</a>
     </div>
 </div>
 <div class="row flex-row intro-row content-row padded-row-30">

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -4,16 +4,44 @@ description: >
     Here you can find an overview of what's happening during the week at Connect.
 permalink: /schedule/
 layout: container-breadcrumb
-css-package: blog
 jumbotron:
     animation: fade
     background-image: /assets/images/content/bkk19-bg.jpg
 ---
-<div class="row" id="register">
+<div class="row" id="schedule">
     <div class="container no-padding">
-        <p>
-            The outline schedule for Linaro Connect Bangkok is now available below:
-        </p>
+        <h3 class="text-center">Overview Schedule</h3>
+        <div class="row">
+            {% for day in site.data.overview-schedule %}
+            <div class="col-md-5ths">
+                <div class="panel-group" id="accordion{{day.day_number}}" role="tablist" aria-multiselectable="true">
+                    <div class="panel panel-default">
+                        <div class="panel-heading" role="tab" id="heading{{day.day_number}}">
+                            <h4 class="panel-title text-center">
+                                <a role="button" data-toggle="collapse" data-parent="#accordion{{day.day_number}}" href="#accordion-collapse{{day.day_number}}"
+                                    aria-expanded="true" aria-controls="accordion-collapse{{day.day_number}}">
+                                    Day {{day.day_number}}: {{day.date}}
+                                </a>
+                            </h4>
+                        </div>
+                        <div id="accordion-collapse{{day.day_number}}" class="panel-collapse collapse dont-collapse-sm" role="tabpanel" aria-labelledby="heading{{day.day_number}}">
+                            <div class="panel-body">
+                                <ul class="list-group">
+                                    {% for slot in day.slots %}
+                                    <li class="list-group-item">
+                                        {{slot.title}}
+                                        <span class="badge">{{slot.time}}</span>
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        <h3 class="text-center">The Linaro Technical Steering Committee Meetings Schedule</h3>
         <iframe width="100%" height="700px" 
         data-src="https://calendar.google.com/calendar/embed?src=so80ggb57tspjgucpqn1gort0s%40group.calendar.google.com&mode=AGENDA&ctz=Asia/Bangkok&dates=20190401%2F20190405"
             class="lazyload"></iframe>


### PR DESCRIPTION
* Removed the schedule modal and linked directly to the schedule page

* Added the committe schedule and overview schedule pages

* Added the overview-schedule as YAML

* Fixed liquid

* Added css for the overview schedule

* Center aligned headings

* Changed list groups to bootstrap collapse panels

* Added css for collapses on schedule page