### PR TITLE
Removed Trusted Firmware from the universal navbar

### DIFF
--- a/_data/universal-nav.yml
+++ b/_data/universal-nav.yml
@@ -17,5 +17,3 @@
       url: https://www.devicetree.org
     - title: OpenDataPlane.org
       url: https://www.opendataplane.org
-    - title: TrustedFirmware.org
-      url: https://www.trustedfirmware.org


### PR DESCRIPTION
Removed Trusted Firmware from the universal navbar