### PR TITLE
Remove stale link, resize containers

### DIFF
--- a/_pages/about/README.md
+++ b/_pages/about/README.md
@@ -40,7 +40,7 @@ flow:
       sections:
         - format: block
           style: text-center text-white
-          item_width: 4
+          item_width: 6
           content: 
               - title: 
                     size: h3
@@ -69,19 +69,6 @@ flow:
                     - title: Submit a Demo
                       url: /demo-friday/
                       icon: fa fa-slideshare
-                      class: btn-primary
-              - title: 
-                    size: h3
-                    content: Socialize
-                url: /about/
-                background_image: /assets/images/content/bkk19-group-photo.jpg
-                text:
-                    content: >
-                        In addition to the regular breaks in the day and informal hacking sessions, there are a range of evening events at which you can network with your peers and get to know the other attendees.
-                buttons:
-                    - title: View Schedule
-                      url: /about/
-                      icon: fa fa-clock-o
                       class: btn-primary
     - row: container_row 
     #   style: dark


### PR DESCRIPTION
Last one for today. Without the `item_width` change, the remaining 2 (was 3) blocks are squashed against the LHS.