### PR TITLE
Redirect /attend back to the front page

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -58,5 +58,6 @@
     "^/blog/linaro-security-groups-plans-linaro-connect-budapest-2017(/?|/index.html)$ https://www.linaro.org/blog/linaro-security-groups-plans-linaro-connect-budapest-2017/ [R,L,NC]",
     "^/blog/las16(/?|/index.html)$ https://www.linaro.org/blog/las16/ [R,L,NC]",
     "^/blog/bud17-1(/?|/index.html)$ https://www.linaro.org/blog/bud17-1/ [R,L,NC]",
-    "^/agendas(/?|/index.html)$ /resources/ [R,L,NC]"    
+    "^/agendas(/?|/index.html)$ /resources/ [R,L,NC]",
+    "^/attend(/?|/index.html)$ / [R,L,NC]"
 ]


### PR DESCRIPTION
/attend has been removed from the repo because it wasn't accessible via links on the Connect website and hadn't been updated.

However, a number of blogs on the Linaro website point to it. Rather than updating those 10 pages, this adds a CloudFront redirect to handle those URLs back to the Connect front page.
