### PR TITLE
Reducing the /resources/ search threshold 

### DIFF
--- a/assets/js/app/resources-search.js
+++ b/assets/js/app/resources-search.js
@@ -5,7 +5,7 @@ var options = {
   findAllMatches: true,
   includeScore: true,
   includeMatches: true,
-  threshold: 0.6,
+  threshold: 0.1,
   location: 0,
   distance: 100,
   maxPatternLength: 32,


### PR DESCRIPTION
Reducing the search threshold - 1 matches everything and 0 is an exact match