### PR TITLE
Replacing 'field' with 'fields' as required by netlifycms

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -506,7 +506,7 @@ collections:
                       - label: "Block Text"
                         name: text_content
                         widget: object
-                        field:
+                        fields:
                             - {label: "Text", name: text, widget: text}
                         required: false
                         hint: "Provide text content for your block"


### PR DESCRIPTION
Replacing 'field' with 'fields' as required by netlifycms