### PR TITLE
Removing the /sponsors/ page from the nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -12,8 +12,6 @@ brand:
 pages:
   - url: /about/
     title: About
-  - title: Sponsor
-    url: /sponsors/
   - active_paths:
       - /resources/
     options:


### PR DESCRIPTION
Removing the /sponsors/ page from the nav