### PR TITLE
Turn off fast build to ensure generated images are up-to-date

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -168,7 +168,7 @@ picture:
   nomarkdown: false
   source: ""
   output: "assets/images"
-  fast_build: true
+  fast_build: false
   suppress_warnings: true
   relative_url: true
 # -------- japr --------


### PR DESCRIPTION
Turn off fast build to ensure generated images are up-to-date